### PR TITLE
Mention software lock-in in sponsored initiatives

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                     <h3>La pandemia ha evidenziato le lacune strutturali nella gestione informatica degli atenei che viola regolarmente il GDPR e ignora i diritti di chi studia. L'Università, come tutte le istituzioni, deve promuovere privacy, trasparenza e indipendenza tecnologica.</h3>
 
                     <h2><b>Formazione</b></h2>
-                    <h3>I bootcamp e i corsi sponsorizzati offrono una formazione volutamente incompleta e inadeguata, formando lavoratori e lavoratrici vincolati alla propria azienda e ai propri strumenti. L'università è luogo e tempo di formazione della persona, non soltanto una fabbrica di lavoratori.</h3>
+                    <h3>I bootcamp e i corsi sponsorizzati offrono una formazione volutamente incompleta e inadeguata, formando lavoratori e lavoratrici vincolati alla propria azienda e ai suoi strumenti. L'università è luogo e tempo di formazione della persona, non soltanto una fabbrica di lavoratori.</h3>
 
                     <h2><b>Benefit</b></h2>
                     <h3>Tutte le forme di benefit che esulano dall'aumento in busta paga sono specchietti per le

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                     <h3>La pandemia ha evidenziato le lacune strutturali nella gestione informatica degli atenei che viola regolarmente il GDPR e ignora i diritti di chi studia. L'Università, come tutte le istituzioni, deve promuovere privacy, trasparenza e indipendenza tecnologica.</h3>
 
                     <h2><b>Formazione</b></h2>
-                    <h3>I bootcamp e i corsi sponsorizzati offrono una formazione volutamente incompleta e inadeguata, formando lavoratori e lavoratrici vincolati alla propria azienda. L'università è luogo e tempo di formazione della persona, non soltanto una fabbrica di lavoratori.</h3>
+                    <h3>I bootcamp e i corsi sponsorizzati offrono una formazione volutamente incompleta e inadeguata, formando lavoratori e lavoratrici vincolati alla propria azienda e ai propri strumenti. L'università è luogo e tempo di formazione della persona, non soltanto una fabbrica di lavoratori.</h3>
 
                     <h2><b>Benefit</b></h2>
                     <h3>Tutte le forme di benefit che esulano dall'aumento in busta paga sono specchietti per le


### PR DESCRIPTION
It may be worth mentioning how aggressive and biased these seminars and training initiatives are in promoting commercial technologies and tools.